### PR TITLE
added a pipeline to create an expo-go link on PRs

### DIFF
--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -1,44 +1,33 @@
 name: Publish Pull Request
-on:
-    pull_request:
-        branches:
-            - dev
+on: pull_request
 
 jobs:
-    publish:
+    update:
+        name: EAS Update
         runs-on: ubuntu-latest
         permissions:
             contents: read
             pull-requests: write
         steps:
-            - name: Checkout
+            - name: Checkout repository
               uses: actions/checkout@v4
 
-            - name: Setup Node.js
+            - name: Setup Node
               uses: actions/setup-node@v4
               with:
                   node-version: 20.x
+                  cache: yarn
 
-            - name: Setup Expo
+            - name: Setup EAS
               uses: expo/expo-github-action@v8
               with:
-                  expo-version: 6.x
-                  expo-cache: true
                   eas-version: latest
                   token: ${{ secrets.EXPO_TOKEN }}
 
-            - name: Install Dependencies
-              run: npm i
+            - name: Install dependencies
+              run: npm install
 
-            - name: Publish to Expo Go
-              run: NODE_ENV=dev expo publish --non-interactive --release-channel pr-${{ github.event.number }}
-
-            - name: Add Expo Link to PR
-              uses: mshick/add-pr-comment@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Create preview
+              uses: expo/expo-github-action/preview@v8
               with:
-                  message: |
-                      ## Check out my PR changes with Expo Go
-                      ![Expo QR](https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=exp://exp.host/@eyalmendel/teen-finance?release-channel=pr-${{ github.event.number }})
-                      **------ Build published to [Expo](https://exp.host/@eyalmendel/teen-finance?release-channel=pr-${{ github.event.number }}) ------**
+                  command: eas update --auto

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -30,4 +30,5 @@ jobs:
             - name: Create preview
               uses: expo/expo-github-action/preview@v8
               with:
+                  qr-target: expo-go
                   command: eas update --auto --environment preview --platform all

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -30,4 +30,4 @@ jobs:
             - name: Create preview
               uses: expo/expo-github-action/preview@v8
               with:
-                  command: eas update --auto
+                  command: eas update --auto --environment preview --platform all

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -1,0 +1,44 @@
+name: Publish Pull Request
+on:
+    pull_request:
+        branches:
+            - dev
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+
+            - name: Setup Expo
+              uses: expo/expo-github-action@v8
+              with:
+                  expo-version: 6.x
+                  expo-cache: true
+                  eas-version: latest
+                  token: ${{ secrets.EXPO_TOKEN }}
+
+            - name: Install Dependencies
+              run: npm i
+
+            - name: Publish to Expo Go
+              run: NODE_ENV=dev expo publish --non-interactive --release-channel pr-${{ github.event.number }}
+
+            - name: Add Expo Link to PR
+              uses: mshick/add-pr-comment@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  message: |
+                      ## Check out my PR changes with Expo Go
+                      ![Expo QR](https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=exp://exp.host/@eyalmendel/teen-finance?release-channel=pr-${{ github.event.number }})
+                      **------ Build published to [Expo](https://exp.host/@eyalmendel/teen-finance?release-channel=pr-${{ github.event.number }}) ------**

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -16,7 +16,7 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 20.x
-                  cache: yarn
+                  cache: npm
 
             - name: Setup EAS
               uses: expo/expo-github-action@v8

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "expo-dev-client": "~5.0.9",
         "expo-image": "~2.0.3",
         "expo-status-bar": "~2.0.0",
+        "expo-updates": "~0.26.13",
         "expo-video": "~2.0.2",
         "react": "18.3.1",
         "react-native": "^0.76.3",
@@ -5216,6 +5217,11 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.13.2.tgz",
+      "integrity": "sha512-2RAAGtkO9vseoJZuW4mhJkiNQ6+FfLrX66OTMq4Qj9mRKZV2Uq/ZquxUGIeJyYqBy4vNYeKbuPd2oJtsV9LBGQ=="
+    },
     "node_modules/expo-file-system": {
       "version": "18.0.7",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.7.tgz",
@@ -5350,6 +5356,39 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.0.0.tgz",
+      "integrity": "sha512-uPiwZjWq3AdFGgY52+I2nGPrNa6izxAglymPXHUZLekZW290GqIUOk7MBNDD4sg4JwUbSi3gdxEurpEvuq+FSg=="
+    },
+    "node_modules/expo-updates": {
+      "version": "0.26.13",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.26.13.tgz",
+      "integrity": "sha512-rNJQ5eCGOGy6Ewxop1Fz3Kh5HXxSoIH480qrbJYqUDrql2J4Fp7cnv36B+Kwz+r+47gwGm1VgzwUbA2PctQc+w==",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.5",
+        "@expo/config": "~10.0.8",
+        "@expo/config-plugins": "~9.0.14",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.13.2",
+        "expo-manifests": "~0.15.5",
+        "expo-structured-headers": "~4.0.0",
+        "expo-updates-interface": "~1.0.0",
+        "fast-glob": "^3.3.2",
+        "fbemitter": "^3.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-updates-interface": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.0.0.tgz",
@@ -5357,6 +5396,11 @@
       "peerDependencies": {
         "expo": "*"
       }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
     },
     "node_modules/expo-video": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-native": "^0.76.3",
     "react-native-screens": "~4.4.0",
     "react-native-safe-area-context": "4.12.0",
-    "expo-dev-client": "~5.0.9"
+    "expo-dev-client": "~5.0.9",
+    "expo-updates": "~0.26.13"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
This pipeline will create a PR comment with a QR code to Expo-Go that will contain the updated app.
This way we could test the changes visually and not just the code without all the manual hassle involved.